### PR TITLE
Implement FastAPI backend skeleton

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+venv
+*.pyc

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,39 @@
+# Pegasus Backend
+
+This directory contains the FastAPI backend that exposes the chat and webhook endpoints for Pegasus.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+cd backend
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Run the application locally:
+
+```bash
+python main.py
+```
+
+The server will be available at `http://127.0.0.1:8000`.
+
+## Docker Usage
+
+Build and run the Docker image:
+
+```bash
+docker build -t pegasus-backend .
+docker run -p 8000:8000 pegasus-backend
+```
+
+## Tests
+
+Run the unit tests with `pytest`:
+
+```bash
+pytest
+```

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Pegasus FastAPI backend package."""

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,4 @@
+"""API routers for the backend."""
+from . import chat_router, webhook_router
+
+__all__ = ["chat_router", "webhook_router"]

--- a/backend/api/chat_router.py
+++ b/backend/api/chat_router.py
@@ -1,0 +1,27 @@
+"""Chat router handling user messages."""
+from fastapi import APIRouter, Depends, HTTPException, Header, status
+from pydantic import BaseModel
+
+from ..core import orchestrator
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+class ChatResponse(BaseModel):
+    response: str
+
+
+def _auth(authorization: str | None = Header(default=None)) -> None:
+    if authorization is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
+
+
+@router.post("/", response_model=ChatResponse)
+async def chat(request: ChatRequest, _: None = Depends(_auth)) -> ChatResponse:
+    """Handle chat messages from the frontend."""
+    reply = orchestrator.handle_chat(request.message)
+    return ChatResponse(response=reply)

--- a/backend/api/webhook_router.py
+++ b/backend/api/webhook_router.py
@@ -1,0 +1,23 @@
+"""Webhook router receiving pipeline notifications."""
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
+
+from ..core import proactive_engine
+
+router = APIRouter(prefix="/webhook", tags=["webhook"])
+
+
+class WebhookPayload(BaseModel):
+    file_path: str
+
+
+def _auth(x_token: str | None = Header(default=None)) -> None:
+    if x_token != "pipeline-secret":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+
+@router.post("/")
+async def webhook(payload: WebhookPayload, _: None = Depends(_auth)) -> dict:
+    """Process notifications from the data pipeline."""
+    proactive_engine.process_notification(payload.dict())
+    return {"status": "received"}

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,4 @@
+"""Core logic for the backend."""
+from . import orchestrator, proactive_engine
+
+__all__ = ["orchestrator", "proactive_engine"]

--- a/backend/core/orchestrator.py
+++ b/backend/core/orchestrator.py
@@ -1,0 +1,10 @@
+"""Reactive orchestrator combining context and user messages."""
+from ..services import vector_db_client, llm_client
+
+
+def handle_chat(message: str) -> str:
+    """Return the LLM-generated reply using vector context."""
+    embedding = vector_db_client.embed(message)
+    passages = vector_db_client.search(embedding, top_k=3)
+    prompt = f"Context: {passages}\nUser: {message}\nAnswer:"
+    return llm_client.generate(prompt)

--- a/backend/core/proactive_engine.py
+++ b/backend/core/proactive_engine.py
@@ -1,0 +1,13 @@
+"""Engine that reacts to pipeline notifications."""
+from ..services import vector_db_client, llm_client
+
+
+def process_notification(payload: dict) -> None:
+    """Analyze new data and potentially notify users."""
+    file_path = payload.get("file_path")
+    if not file_path:
+        return
+    embedding = vector_db_client.embed(file_path)
+    passages = vector_db_client.search(embedding, top_k=3)
+    prompt = f"Summarize: {passages}. Should notify?"
+    llm_client.generate(prompt)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,21 @@
+"""FastAPI application entry point."""
+from fastapi import FastAPI
+
+from .api import chat_router, webhook_router
+
+app = FastAPI(title="Pegasus Backend")
+
+app.include_router(chat_router.router)
+app.include_router(webhook_router.router)
+
+
+@app.get("/health")
+def health() -> dict:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    import uvicorn
+
+    uvicorn.run("backend.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,4 @@
+"""Service clients used by the backend."""
+from . import llm_client, vector_db_client
+
+__all__ = ["llm_client", "vector_db_client"]

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -1,0 +1,30 @@
+"""Client for external LLM providers."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import requests
+
+LOGGER = logging.getLogger(__name__)
+
+API_URL = os.environ.get("LLM_API_URL", "https://api.openai.com/v1/completions")
+API_KEY = os.environ.get("LLM_API_KEY")
+
+
+def generate(prompt: str) -> str:
+    """Send the prompt to the LLM provider and return the answer."""
+    if not API_KEY:
+        raise RuntimeError("LLM_API_KEY not configured")
+
+    headers = {"Authorization": f"Bearer {API_KEY}"}
+    data: dict[str, Any] = {
+        "model": "gpt-3.5-turbo",
+        "prompt": prompt,
+        "max_tokens": 256,
+    }
+    resp = requests.post(API_URL, json=data, headers=headers, timeout=30)
+    resp.raise_for_status()
+    result = resp.json()
+    return result.get("choices", [{}])[0].get("text", "")

--- a/backend/services/vector_db_client.py
+++ b/backend/services/vector_db_client.py
@@ -1,0 +1,40 @@
+"""Client for the ChromaDB vector database."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+
+try:
+    import chromadb
+    from chromadb.utils import embedding_functions
+except Exception:  # pragma: no cover - dependency optional
+    chromadb = None
+
+LOGGER = logging.getLogger(__name__)
+DB_PATH = Path(__file__).resolve().parents[1] / "database"
+
+_client = None
+_embedder = None
+
+
+def _connect():
+    global _client, _embedder
+    if _client is None:
+        if chromadb is None:
+            raise RuntimeError("chromadb package not installed")
+        _client = chromadb.PersistentClient(path=str(DB_PATH))
+        _embedder = embedding_functions.SentenceTransformerEmbeddingFunction()
+    return _client
+
+
+def embed(text: str) -> List[float]:
+    _connect()
+    return _embedder(text)
+
+
+def search(query_embedding: List[float], top_k: int) -> List[str]:
+    client = _connect()
+    collection = client.get_or_create_collection("documents")
+    results = collection.query(query_embeddings=[query_embedding], n_results=top_k)
+    return [m.get("content", "") for m in results.get("metadatas", [{}])[0]]

--- a/backend/tests/test_chat_router.py
+++ b/backend/tests/test_chat_router.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_chat_missing_auth() -> None:
+    resp = client.post("/chat/", json={"message": "hi"})
+    assert resp.status_code == 401
+
+
+def test_chat_ok(monkeypatch) -> None:
+    monkeypatch.setattr("backend.core.orchestrator.handle_chat", lambda msg: "pong")
+    resp = client.post("/chat/", json={"message": "ping"}, headers={"Authorization": "token"})
+    assert resp.status_code == 200
+    assert resp.json() == {"response": "pong"}

--- a/backend/tests/test_webhook_router.py
+++ b/backend/tests/test_webhook_router.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_webhook_bad_token() -> None:
+    resp = client.post("/webhook/", json={"file_path": "a"})
+    assert resp.status_code == 401
+
+
+def test_webhook_ok(monkeypatch) -> None:
+    called = {}
+    def fake_process(payload):
+        called['ok'] = payload
+    monkeypatch.setattr("backend.core.proactive_engine.process_notification", fake_process)
+    resp = client.post("/webhook/", json={"file_path": "f"}, headers={"X-Token": "pipeline-secret"})
+    assert resp.status_code == 200
+    assert called['ok'] == {"file_path": "f"}


### PR DESCRIPTION
## Summary
- scaffold `backend` with FastAPI routers and services
- provide Dockerfile and tests
- document setup and Docker usage

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68582d3e9ef88326b43d9290d61614a9